### PR TITLE
[CUPS] Include all printer drivers

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -10,13 +10,11 @@ RUN apt-get update \
         libnss-mdns \
         dbus \
         colord \
-        printer-driver-all \
-        printer-driver-gutenprint \
+        printer-driver-all-enforce \
         openprinting-ppds \
         hpijs-ppds \
         hp-ppd  \
         hplip \
-        printer-driver-foo2zjs \
         gnupg2 \
         lsb-release \
         nano \


### PR DESCRIPTION
The package `printer-driver-all` does not include drivers, it's only a meta package that _recommends_ other drivers, and that recommendation is negated with `--no-install-recommends` passed to apt-get.  This issue existed all the way back in the original repo which [missed some drivers](https://github.com/ncarr/addon-repository/issues/2), but this seems the only maintained fork so I'm pushing the fix here.

This merge request replaces [printer-driver-all](https://packages.debian.org/bullseye/printer-driver-all) with [printer-driver-all-enforce](https://packages.debian.org/bullseye/printer-driver-all-enforce) which actually depends on all drivers.