### PR TITLE
[adsb-multi-portal-feeder] Update to 1.27.1.1

### DIFF
--- a/adsb-multi-portal-feeder/CHANGELOG.md
+++ b/adsb-multi-portal-feeder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.27.1.1] - 2023-06-24
+
+- Update `thomx/fr24feed-piaware` to `1.27.1` that fixes RadarBox mlat support - see [their release notes](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/releases/tag/1.27.1) for more
+- Update [adsb-hassio-sensors](https://github.com/plo53/adsb-hassio-sensors) to `1.1.1` that brings more aircraft sensors - see INFO and [their repo](https://github.com/plo53/adsb-hassio-sensors) for more
+
 ## [1.27.0] - 2023-06-24
 
 - Update `thomx/fr24feed-piaware` to `1.27.0` that brings RadarBox support - see [their release notes](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/releases/tag/1.27.0) for more

--- a/adsb-multi-portal-feeder/Dockerfile
+++ b/adsb-multi-portal-feeder/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y curl jq && mkdir /tmp/bashio \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 # Add hassio sensors - thx to https://github.com/plo53
-ARG version=1.0.1
-ARG sha256sum=40636f3dae484a82485f7c08cbc1f4a413e2ccf3c8b7c3a1e67651974645067d
+ARG version=1.1.1
+ARG sha256sum=267c465e192a44734345932dc8856cc9b82c9023ea59ea8f616d3340e8dc3006
 ADD https://github.com/plo53/adsb-hassio-sensors/archive/refs/tags/${version}.tar.gz /tmp/
 RUN echo "${sha256sum}  /tmp/${version}.tar.gz" | sha256sum --check
 RUN tar xvfz /tmp/${version}.tar.gz adsb-hassio-sensors-${version}/{etc,usr} --strip-components=1 -C /

--- a/adsb-multi-portal-feeder/build.json
+++ b/adsb-multi-portal-feeder/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "armv7": "thomx/fr24feed-piaware:1.27.0",
-    "aarch64": "thomx/fr24feed-piaware:1.27.0",
-    "amd64": "thomx/fr24feed-piaware:1.27.0"
+    "armv7": "thomx/fr24feed-piaware:1.27.1",
+    "aarch64": "thomx/fr24feed-piaware:1.27.1",
+    "amd64": "thomx/fr24feed-piaware:1.27.1"
   }
 }

--- a/adsb-multi-portal-feeder/config.yaml
+++ b/adsb-multi-portal-feeder/config.yaml
@@ -2,7 +2,7 @@ slug: adsb-multi-portal-feeder
 url: https://github.com/MaxWinterstein/homeassistant-addons/
 image: ghcr.io/maxwinterstein/homeassistant-adsb-multi-portal-feeder-{arch}
 usb: true
-version: 1.27.0
+version: 1.27.1.1
 arch:
   - armv7
   - aarch64


### PR DESCRIPTION
- Update `thomx/fr24feed-piaware` to `1.27.1` that fixes RadarBox mlat support - see [their release notes](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/releases/tag/1.27.1) for more
- Update [adsb-hassio-sensors](https://github.com/plo53/adsb-hassio-sensors) to `1.1.1` that brings more aircraft sensors - see INFO and [their repo](https://github.com/plo53/adsb-hassio-sensors) for more