### PR TITLE
fix(cups): Preserve existing configuration on restart

### DIFF
--- a/cups/rootfs/run.sh
+++ b/cups/rootfs/run.sh
@@ -36,9 +36,16 @@ until [ -e /var/run/avahi-daemon/socket ]; do
 done
 
 bashio::log.info "Preparing directories"
-cp -v -R /etc/cups /data
-rm -v -fR /etc/cups
 
+# Only copy default config if /data/cups doesn't exist (preserves existing config on restart)
+if [ ! -d /data/cups ]; then
+    bashio::log.info "First run detected - copying default CUPS configuration to /data/cups"
+    cp -v -R /etc/cups /data
+else
+    bashio::log.info "Existing CUPS configuration found in /data/cups - preserving it"
+fi
+
+rm -v -fR /etc/cups
 ln -v -s /data/cups /etc/cups
 
 bashio::log.info "Starting CUPS server as CMD from S6"


### PR DESCRIPTION
## Summary

Hi @MaxWinterstein - I noticed that on my HA install, anytime the CUPS server restarts it resets the config to default (which in my case breaks printing) and wipes out all configuration (printers, settings, cupsd.conf changes).

Best I can tell, the current `run.sh` unconditionally copies `/etc/cups` to `/data/cups` on every startup:

```bash
cp -v -R /etc/cups /data
```

## Solution

Added a check to only copy the default configuration on first run:

```bash
if [ ! -d /data/cups ]; then
    bashio::log.info "First run detected - copying default CUPS configuration to /data/cups"
    cp -v -R /etc/cups /data
else
    bashio::log.info "Existing CUPS configuration found in /data/cups - preserving it"
fi
```

## Testing

Tested on Home Assistant OS 16.2 with amd64 architecture:
- Fresh install correctly initializes config
- Restart preserves existing configuration
- Log output confirms which path is taken

## Related Issues

This may also address issue #261 (CUPS Config and TLS) as users can now persist their TLS configuration changes.

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where CUPS settings were reset on each service restart. Configuration changes are now persisted and only initialized on first run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->