### PR TITLE
fix(renovate): drop invalid wildcard matchPackageNames

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,7 +60,6 @@
       groupName: "planefence dependencies",
     },
     {
-      matchPackageNames: ["*", "/.*/"],
       matchFileNames: ["*.*", ".gitlab/**"],
       commitMessagePrefix: "",
     },


### PR DESCRIPTION
Fixes #562.

### What's wrong

Renovate stopped opening PRs on this repo after **2026-06-10** (#561 was the last one) and filed #562 the next morning:

> `packageRules[3].matchPackageNames`: Your input contains `*` or `**` along with other patterns. Please remove them, as `*` or `**` matches all patterns.

That rule read:

```json5
{
  matchPackageNames: ["*", "/.*/"],
  matchFileNames: ["*.*", ".gitlab/**"],
  commitMessagePrefix: "",
},
```

`"*"` and `"/.*/"` each already match every package, so listing both is what Renovate rejects — and the key was never narrowing anything to begin with.

### The change

Delete the `matchPackageNames` line. The rule stays scoped by `matchFileNames`, which is what was actually doing the work: blanking the global `commitMessagePrefix: "[{{packageFileDir}}]"` for root-level files and `.gitlab/**`, where there is no meaningful package dir. Behaviour is unchanged.

### Note on verification

`renovate-config-validator` v42.99.0 classifies this file as a *global* config when run standalone, and global validation skips the repo-level `packageRules` checks — so it reports success both before and after this change locally. The authoritative signal is Renovate's own run against the repo, which named `packageRules[3]` explicitly in #562, plus 2.5 months of silence from the bot.

Since this PR touches `.github/renovate.json5`, the `Validate Renovate Config` workflow triggers on it. That workflow has been red since 2026-03-27, so its result here is worth a look either way.

### After merge

Don't close #562 by hand, Renovate closes it itself on the next successful run. Then tick `rebase-all-open-prs` on the Dependency Dashboard so the 7 stalled PRs rebase before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)