### PR TITLE
docs: put the install button first and add the missing add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _Everything here is meant to be **experimental**. Happy to see feedback!_
 
 [![Add repository on my Home Assistant][repository-badge]][repository-url]
 
-If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: `https://github.com/MaxWinterstein/homeassistant-addons/`
+If you want to add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: `https://github.com/MaxWinterstein/homeassistant-addons/`
 
 ## Add-ons
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Observe flight traffic using some cheap ADS-B USB-Stick and feed towards FlightR
 
 Based on the incredible [docker-fr24feed-piaware-dump1090](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090) docker image by [Thom-x](https://github.com/Thom-x).
 
-### <img src="fr24-sharing-key-generator/icon.png" width="40px"> FlightRadar24 Sharing Key Generator
+### <img src="fr24-sharing-key-generator/icon.png" width="40px" alt=""> FlightRadar24 Sharing Key Generator
 
 Quickly generate a FlightRadar24 sharing key and watch the signup process in your browser, without leaving Home Assistant. Handy to get the key needed by the ADS-B Multi Portal Feeder.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 _Everything here is meant to be **experimental**. Happy to see feedback!_
 
-## Home Assistant Addon repository containing
+## Installation
+
+[![Add repository on my Home Assistant][repository-badge]][repository-url]
+
+If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: `https://github.com/MaxWinterstein/homeassistant-addons/`
+
+## Add-ons
 
 ### <img src="angryipscanner/icon.png" width="40px"> Angry IP Scanner
 
@@ -15,6 +21,12 @@ Wraps the well known [Angry IP Scanner](https://angryip.org/) to make it usable 
 Observe flight traffic using some cheap ADS-B USB-Stick and feed towards FlightRadar24 and FlightAware.
 
 Based on the incredible [docker-fr24feed-piaware-dump1090](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090) docker image by [Thom-x](https://github.com/Thom-x).
+
+### <img src="fr24-sharing-key-generator/icon.png" width="40px"> FlightRadar24 Sharing Key Generator
+
+Quickly generate a FlightRadar24 sharing key and watch the signup process in your browser, without leaving Home Assistant. Handy to get the key needed by the ADS-B Multi Portal Feeder.
+
+Also based on [docker-fr24feed-piaware-dump1090](https://github.com/Thom-x/docker-fr24feed-piaware-dump1090) by [Thom-x](https://github.com/Thom-x).
 
 ### <img src="cups/icon.png" width="40px"> CUPS ([cups.org](http://www.cups.org))
 
@@ -31,12 +43,6 @@ Integrate your TooGoodToGo favourites to Home Assistant via MQTT.
 Track aircraft flying near your ADS-B receiver. Logs low-altitude and nearby flights, generates noise statistics, and can send alerts via Discord, Mastodon, Telegram, and BlueSky.
 
 Based on [docker-planefence](https://github.com/sdr-enthusiasts/docker-planefence) by kx1t / SDR-Enthusiasts.
-
-## Installation
-
-[![Add repository on my Home Assistant][repository-badge]][repository-url]
-
-If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://home-assistant.io/hassio/installing_third_party_addons). Use the following URL to add this repository: `https://github.com/MaxWinterstein/homeassistant-addons/`
 
 ## Deprecated add-ons
 
@@ -62,9 +68,6 @@ See https://community.home-assistant.io/t/portainer-v2-6-2-unable-to-start-conta
 
 Forwards Eufy Security push notifications to Home Assistant via MQTT.
 
-[repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
-[repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FMaxWinterstein%2Fhomeassistant-addons
-
 ### <img src="awtrix/icon.png" width="40px"> AWTRIX Controller
 
 #### AWTRIX 3 no longer needs an running server
@@ -80,3 +83,6 @@ Made for the awesome AWTRIX project by blueforcer. Even it is discontinued, I li
 #### Never really worked and no longer used by me
 
 Small proxy to add OctoPrint to the Home Assistant.
+
+[repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
+[repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FMaxWinterstein%2Fhomeassistant-addons


### PR DESCRIPTION
Three fixes to the README, no rewriting of anything that already read fine.

### The store has six add-ons, the README described five

`fr24-sharing-key-generator` (**2.6.1**, active, has its own icon and ingress UI) was never added to the README. Anyone browsing this repo could not tell it exists. It now sits directly after the ADS-B Multi Portal Feeder, since it generates the key that feeder needs.

Blurb is taken from the add-on's own `config.yaml` (`Quickly generate FlightRadar24 Sharing Key`) and its README, not invented.

### The install button was below the fold

`## Installation` and the one-click **Add repository to my Home Assistant** button were at line 37, underneath every add-on description. That button is the single thing most visitors come here for. It now appears immediately after the intro.

The heading `## Home Assistant Addon repository containing` used to run on grammatically from the title, which stopped working once Installation came first, so it is now just `## Add-ons`.

### The link definitions were stranded mid-document

`[repository-badge]:` and `[repository-url]:` sat at lines 65-66, in the middle of the deprecated section, with the **AWTRIX** and **OctoPrint** entries orphaned after them. Moved to the end of the file; both entries now sit under `## Deprecated add-ons` with ioBroker, Portainer and Eufy.

### Not touched

The ko-fi badge, the experimental line, every existing add-on blurb, and all deprecated-section copy are byte-identical.

### Checks

- every `icon.png` path referenced was confirmed to exist via the contents API
- `prettier` and `typos` pass locally via pre-commit
- reference links still resolve

An earlier draft of this also added a summary paragraph naming all six add-ons; I dropped it, as it duplicated the headings ten lines below and hardcoded a count that goes stale the next time you add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)