### PR TITLE
chore: add a bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Something in one of the add-ons does not work
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Everything here is experimental, so bugs happen. The more of the below you fill in, the less back and forth we need.
+
+  - type: dropdown
+    id: addon
+    attributes:
+      label: Add-on
+      description: Which add-on is this about?
+      options:
+        - ADS-B Multi-Portal Feeder
+        - Angry IP Scanner
+        - CUPS
+        - FlightRadar24 Sharing Key Generator
+        - Planefence
+        - TooGoodToGo Home Assistant MQTT Bridge
+    validations:
+      required: true
+
+  - type: input
+    id: addon-version
+    attributes:
+      label: Add-on version
+      description: Shown on the add-on page in Home Assistant, e.g. 2.6.1.1
+    validations:
+      required: true
+
+  - type: input
+    id: ha-version
+    attributes:
+      label: Home Assistant version
+      description: Settings -> About, e.g. 2026.8.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      description: Settings -> System -> Repairs -> three dot menu -> System information
+      options:
+        - aarch64
+        - amd64
+        - armv7
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what did you expect?
+      description: Also add the steps to get there, if it is not obvious.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Add-on log
+      description: From the add-on's Log tab. Please remove tokens, passwords and mail addresses.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Home Assistant community
+    url: https://community.home-assistant.io/
+    about: General Home Assistant questions that are not about one of these add-ons.
+  - name: TooGoodToGo MQTT Bridge
+    url: https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge/issues
+    about: Bugs in the bridge itself, rather than in packaging it as an add-on.


### PR DESCRIPTION
There is no `.github/ISSUE_TEMPLATE/` here today, which is why open issues have titles like *"ADS-B Feeder"* and *"Bridge won't start anymore"* with no version, no architecture and no log attached. Every one of those costs a round trip before you can even look at it.

### The form asks for

- **which add-on** (dropdown of the six active ones, names taken from each `config.yaml`)
- **add-on version** and **Home Assistant version**
- **architecture** (dropdown)
- what happened / what was expected
- the add-on log, in a `render: shell` textarea

Kept deliberately short. A twenty-field form gets abandoned.

### Two details worth checking

**The architecture dropdown offers only `aarch64`, `amd64` and `armv7`.** An earlier draft also listed `armhf` and `i386`, which would have been a trap: no add-on in this repo builds for either. `adsb-multi-portal-feeder`, `angryipscanner`, `cups`, `fr24-sharing-key-generator` and `planefence` all declare `aarch64` + `amd64` only, and `armv7` appears solely in `toogoodtogo-ha-mqtt-bridge`. Since the field is required, offering an impossible answer would have sent you chasing a phantom.

**Discussions is disabled on this repo** (`has_discussions: false`), so `config.yml` deliberately does not link there. General Home Assistant questions go to the community forum instead, and bridge-specific bugs to that repo's tracker.

`blank_issues_enabled` is left `true` — for a hobby repo, forcing everyone through a form tends to lose the odd useful report.

The `bug` label already exists, so `labels: ["bug"]` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)