### PR TITLE
Repoint four ko-fi buttons at a CDN that still exists

### DIFF
--- a/eufy-ha-mqtt-bridge/README.md
+++ b/eufy-ha-mqtt-bridge/README.md
@@ -16,7 +16,7 @@
 ![Supports armhf Architecture][armhf-shield]
 ![Supports i386 Architecture][i386-shield]
 
-<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'></a>
+<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 **Based on https://github.com/matijse/eufy-ha-mqtt-bridge.**
 

--- a/ioBroker/README.md
+++ b/ioBroker/README.md
@@ -18,7 +18,7 @@
 ![Supports armhf Architecture][armhf-shield]
 ![Supports i386 Architecture][i386-shield]
 
-<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'></a>
+<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 This is a pretty basic implementation of ioBroker as Home Assistant Add-on.
 It is meant to provide some playground.
@@ -28,7 +28,7 @@ and https://community.home-assistant.io/t/eufy-camera-integration/121758
 
 See the Documentation (DOCS.md) for more info.
 
-**This is no official add-on, neither from Home Assisant, nor from ioBroker.**
+**This is no official add-on, neither from Home Assistant, nor from ioBroker.**
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/octoprint-proxy/README.md
+++ b/octoprint-proxy/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Add-on: OctoPrint Proxy
 
-<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'></a>
+<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 Small _haproxy_ based reverse proxy to have OctoPrint accessible from Home Assistant with a memory consumption less than 10Mbyte.
 

--- a/toogoodtogo-ha-mqtt-bridge/README.md
+++ b/toogoodtogo-ha-mqtt-bridge/README.md
@@ -17,7 +17,7 @@
 ![Supports armhf Architecture][armhf-shield]
 ![Supports i386 Architecture][i386-shield]
 
-<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='35' style='border:0px;height:46px;' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'></a>
+<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 Based on https://github.com/MaxWinterstein/toogoodtogo-ha-mqtt-bridge
 


### PR DESCRIPTION
Same class of problem as the one just fixed in the bridge repo, but four more instances hiding in the add-on READMEs.

### The defect

```
toogoodtogo-ha-mqtt-bridge/README.md:20
eufy-ha-mqtt-bridge/README.md:19
octoprint-proxy/README.md:3
ioBroker/README.md:21
```

All four load the button from `https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0`. That is Microsoft's retired Azure CDN, and the hostname **no longer has a DNS record at all**:

```
$ getent hosts az743702.vo.msecnd.net
→ NXDOMAIN
```

So the button is a broken image on GitHub, and for the add-ons whose README is their add-on page, inside the Home Assistant UI too.

### The fix

Repointed to the exact markup already used by the other ten ko-fi buttons in this repo:

```html
<a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
```

All 14 buttons in the repo now use one identical string. `storage.ko-fi.com/cdn/kofi6.png?v=6` returns 200.

### One thing I deliberately did not do

`toogoodtogo-ha-mqtt-bridge/README.md` now has a working button on **both** line 1 and line 20. That looked like a duplicate to remove, until I checked: `cups/README.md` has buttons on lines 3 and 149, and `fr24-sharing-key-generator/README.md` on lines 3 and 128. Two buttons per README is your existing pattern, so removing one is a layout choice rather than a fix. Left it; say the word if you'd rather drop it.

### Also

The `typos` hook fixed **"Home Assisant" → "Home Assistant"** in `ioBroker/README.md`. Unrelated to the CDN, but that file is now in scope so pre-commit.ci would fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)