### PR TITLE
Correct the fr24 options docs against what the add-on actually asks

### DIFF
--- a/fr24-sharing-key-generator/README.md
+++ b/fr24-sharing-key-generator/README.md
@@ -4,7 +4,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
 
 Quickly generate a Flightradar24 sharing key and view the setup process in your browser - all without leaving Home Assistant!
 
@@ -34,7 +33,7 @@ Before starting the add-on, configure these essential parameters in the add-on o
 - **email**: Your email address (will receive the sharing key as backup)
 - **latitude**: Your receiver's latitude (e.g., `52.5200`)
 - **longitude**: Your receiver's longitude (e.g., `13.4050`)
-- **altitude**: Your receiver's altitude in meters above sea level
+- **altitude**: Your receiver's altitude in feet above sea level
 
 ### Optional Settings
 
@@ -43,12 +42,12 @@ Before starting the add-on, configure these essential parameters in the add-on o
 - **confirm_settings**: Auto-confirm settings during signup (default: `true`)
 - **autoconfig**: Enable automatic configuration (default: `false`)
 - **receiver_type**: Type of receiver hardware
-  - `1`: DVB-T
-  - `2`: rtl-sdr
-  - `3`: Beast
-  - `4`: AVR
-  - `5`: Radarcape
-  - `6`: Other
+  - `1`: DVBT Stick
+  - `2`: SBS1
+  - `3`: SBS3
+  - `4`: ModeS Beast
+  - `5`: AVR Compatible
+  - `6`: microADSB
 - **raw_feed**: Enable raw data feed (default: `false`)
 - **base_feed**: Enable base station feed (default: `false`)
 
@@ -60,10 +59,10 @@ sharing_key: ""
 mlat: true
 latitude: 52.5200
 longitude: 13.4050
-altitude: 34
+altitude: 112
 confirm_settings: true
 autoconfig: false
-receiver_type: "2"
+receiver_type: "1"
 raw_feed: false
 base_feed: false
 ```
@@ -135,6 +134,5 @@ This add-on uses the excellent [docker-fr24feed-piaware-dump1090](https://github
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FMaxWinterstein%2Fhomeassistant-addons


### PR DESCRIPTION
`fr24-sharing-key-generator/README.md` contradicts the add-on's own `translations/en.json` — which is the text Home Assistant shows in the options UI, and which mirrors what `fr24feed --signup` actually prompts for. The README is the wrong side each time.

These matter more than a normal doc typo, because the values get sent to Flightradar24 at signup and end up baked into the sharing key.

### altitude is in feet, not metres

| | |
|---|---|
| README said | *"Your receiver's altitude in **meters** above sea level"* |
| `translations/en.json` | *"Antenna altitude above sea level in **feet**."* |

`signup.exp` pipes the value straight into `fr24feed --signup`, which asks in feet. Anyone following the README registers roughly **a third** of their true altitude.

The example was `altitude: 34` — Berlin, in metres. Now `112`, the same place in feet.

### receiver_type: five of the six entries were wrong

| value | README said | actually |
|---|---|---|
| 1 | DVB-T | DVBT Stick |
| 2 | rtl-sdr | **SBS1** |
| 3 | Beast | **SBS3** |
| 4 | AVR | **ModeS Beast** |
| 5 | Radarcape | **AVR Compatible** |
| 6 | Other | **microADSB** |

Picking *"3: Beast"* from the old table registered an **SBS3**. The whole list was shifted.

The example config said `receiver_type: "2"`, which the old table called rtl-sdr — the common case. Under the real mapping an rtl-sdr dongle is `1`, so the example is now `"1"`. **This changes what the example means**, and is the one edit here that is a judgement call rather than a straight correction — flagging it explicitly in case you'd rather it stayed a literal `2`.

### armv7 badge

`config.yaml` declares `arch: [amd64, aarch64]`. Home Assistant will not offer this add-on on an armv7 host at all, and no armv7 image exists for the current version — the `-armv7` package stops at 0.4.0 while `config.yaml` is at 2.6.1. Badge and its link definition removed; `aarch64` and `amd64` are untouched and correct.

### Not changed

No prose was rewritten. Every edit above is a value or a unit that was factually wrong.

`typos` and `prettier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)