### PR TITLE
Pass the comment body through env, like the other two already are

### DIFF
--- a/.github/workflows/comment_actions.yaml
+++ b/.github/workflows/comment_actions.yaml
@@ -44,9 +44,10 @@ jobs:
         env:
           ISSUE_BODY: ${{ github.event_name == 'pull_request' && github.event.pull_request.body || github.event.issue.body }}
           PR_TITLE: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.event.issue.title }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
 
-          comment_body="${{ github.event.comment.body }}"
+          comment_body="$COMMENT_BODY"
           ADDON=''
 
           # Check if the PR title has an add-on mentioned


### PR DESCRIPTION
### The pattern

`.github/workflows/comment_actions.yaml` line 49:

```yaml
        env:
          ISSUE_BODY: ${{ ... }}      # correct
          PR_TITLE:   ${{ ... }}      # correct
        run: |
          comment_body="${{ github.event.comment.body }}"    # <- spliced into the script
```

`${{ }}` is substituted into the script text *before* bash sees it, so a comment body containing a `"` followed by a backtick or `$(...)` executes as shell. This job has `secrets.GH_PAT_MAXWINTERSTEINBOT` in scope.

### Honest severity

**This is not exploitable by anyone else today.** The job's `if:` guard requires `github.event.comment.user.login == 'MaxWinterstein'`, so only you can trigger it — and if you wanted to run commands in your own workflow, you have easier ways.

So this is hardening, not an incident. It is worth the two-line change because:

- it is one edit to that `if:` away from being reachable, and the guard is there for access control, not for injection safety
- **the same step already does it correctly twice.** `ISSUE_BODY` and `PR_TITLE` both go through `env:`. `comment_body` was just missed
- even self-triggered, a `/release` comment containing a stray backtick breaks the job in a way that is annoying to debug

### The change

Adds `COMMENT_BODY` to the existing `env:` block and reads `"$COMMENT_BODY"`. Values reaching the script through `env:` are never parsed as script text.

Behaviour is identical for every comment that does not contain shell metacharacters. The `${{ }}` uses in `if:` conditions elsewhere in the file are fine as-is — those are expression context, not shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)