### PR TITLE
[toogoodtogo-ha-mqtt-bridge] Mask the MQTT password in the add-on UI

### DIFF
--- a/toogoodtogo-ha-mqtt-bridge/CHANGELOG.md
+++ b/toogoodtogo-ha-mqtt-bridge/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## [3.5.0.1] - 2026-08-29
+
+### Fixed
+
+- The MQTT password is now stored as a `password` field, so Home Assistant masks it in the add-on configuration instead of showing it in cleartext.
+
 ## [3.5.0.0] - 2025-07-20
 
 ### Changed

--- a/toogoodtogo-ha-mqtt-bridge/CHANGELOG.md
+++ b/toogoodtogo-ha-mqtt-bridge/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 <!-- towncrier release notes start -->
 
-## [3.5.0.1] - 2026-08-29
-
-### Fixed
-
-- The MQTT password is now stored as a `password` field, so Home Assistant masks it in the add-on configuration instead of showing it in cleartext.
-
 ## [3.5.0.0] - 2025-07-20
 
 ### Changed

--- a/toogoodtogo-ha-mqtt-bridge/changelog.d/578.fixed.md
+++ b/toogoodtogo-ha-mqtt-bridge/changelog.d/578.fixed.md
@@ -1,0 +1,1 @@
+The MQTT password is now stored as a `password` field, so Home Assistant masks it in the add-on configuration instead of showing it in cleartext.

--- a/toogoodtogo-ha-mqtt-bridge/config.yaml
+++ b/toogoodtogo-ha-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: TooGoodToGo Home Assistant MQTT Bridge
-version: 3.5.0.1
+version: 3.5.0.0
 image: ghcr.io/maxwinterstein/homeassistant-addon-toogoodtogo-ha-mqtt-bridge-{arch}
 slug: tgtg-ha-mqtt-bridge
 description: Publish TooGoodToGo stock as MQTT messages

--- a/toogoodtogo-ha-mqtt-bridge/config.yaml
+++ b/toogoodtogo-ha-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: TooGoodToGo Home Assistant MQTT Bridge
-version: 3.5.0.0
+version: 3.5.0.1
 image: ghcr.io/maxwinterstein/homeassistant-addon-toogoodtogo-ha-mqtt-bridge-{arch}
 slug: tgtg-ha-mqtt-bridge
 description: Publish TooGoodToGo stock as MQTT messages
@@ -28,7 +28,7 @@ schema:
     host: str
     port: int
     username: str?
-    password: str?
+    password: password?
   tgtg:
     email: str
     language: str


### PR DESCRIPTION
```diff
-    password: str?
+    password: password?
```

Home Assistant's add-on schema has a dedicated `password` type that masks the field in the Configuration tab and keeps it out of the rendered YAML view. `str` does not, so the user's MQTT broker password currently sits visible in the UI.

This is your own convention, not my preference — `planefence/config.yaml` already uses `password?` for all eight of its secrets, including `PF_MQTT_PASSWORD`. This add-on was the odd one out.

No migration concern: the type only affects how a string is rendered and validated, so existing configurations keep working.

### About the version bump

Bumped `3.5.0.0` → `3.5.0.1` with a CHANGELOG entry, because touching an add-on's `config.yaml` makes `Check if CHANGELOG.md changed` a required check, and without a bump nobody's installed add-on would pick the change up.

**If you'd rather batch this into the next release, drop the last commit's version/CHANGELOG hunk** — the schema change alone is the substance here. There are also 18 unreleased newsfragments sitting in `changelog.d/`, so you may prefer to fold this in when those go out.

This was originally part of #576. Split out so that PR can stay docs-only and merge without triggering a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)