### PR TITLE
Rebuild when the Dockerfile changes, not only config.*

### DIFF
--- a/.github/paths-filter.yml
+++ b/.github/paths-filter.yml
@@ -1,12 +1,77 @@
 # AUTO BUILDS #
 # From https://github.com/Poeschl/Hassio-Addons
-# name: slug/filename ; could be slug/config.* for all files
-adsb-multi-portal-feeder: adsb-multi-portal-feeder/config.* # Image : yes
-angryipscanner: angryipscanner/config.* # Image : yes
-toogoodtogo-ha-mqtt-bridge: toogoodtogo-ha-mqtt-bridge/config.*
-octoprint-proxy: octoprint-proxy/config.*
-cups: cups/config.*
-cups-dev: cups-dev/config.*
-awtrix: awtrix/config.*
-fr24-sharing-key-generator: fr24-sharing-key-generator/config.*
-planefence: planefence/config.*
+#
+# Which files make an add-on's published image stale. Used by onpush_build.yaml to
+# decide what to rebuild, and by onpr_check-pr.yaml to decide what to test-build.
+#
+# Anything that ends up inside the image belongs here: config.*, Dockerfile, build.*,
+# rootfs/**, apparmor.txt and helper scripts. Documentation and artwork are excluded,
+# since changing them cannot change the built image.
+#
+# Only add-ons that publish to ghcr belong in this file. eufy-ha-mqtt-bridge, ioBroker
+# and portainer have no `image:` key and are built on the user's device, so there is
+# nothing for CI to push.
+
+adsb-multi-portal-feeder:
+  - "adsb-multi-portal-feeder/**"
+  - "!adsb-multi-portal-feeder/*.md"
+  - "!adsb-multi-portal-feeder/images/**"
+  - "!adsb-multi-portal-feeder/icon.png"
+  - "!adsb-multi-portal-feeder/logo.png"
+  - "!adsb-multi-portal-feeder/changelog.d/**"
+
+angryipscanner:
+  - "angryipscanner/**"
+  - "!angryipscanner/*.md"
+  - "!angryipscanner/images/**"
+  - "!angryipscanner/icon.png"
+  - "!angryipscanner/logo.png"
+  - "!angryipscanner/changelog.d/**"
+
+awtrix:
+  - "awtrix/**"
+  - "!awtrix/*.md"
+  - "!awtrix/images/**"
+  - "!awtrix/icon.png"
+  - "!awtrix/logo.png"
+  - "!awtrix/changelog.d/**"
+
+cups:
+  - "cups/**"
+  - "!cups/*.md"
+  - "!cups/images/**"
+  - "!cups/icon.png"
+  - "!cups/logo.png"
+  - "!cups/changelog.d/**"
+
+fr24-sharing-key-generator:
+  - "fr24-sharing-key-generator/**"
+  - "!fr24-sharing-key-generator/*.md"
+  - "!fr24-sharing-key-generator/images/**"
+  - "!fr24-sharing-key-generator/icon.png"
+  - "!fr24-sharing-key-generator/logo.png"
+  - "!fr24-sharing-key-generator/changelog.d/**"
+
+octoprint-proxy:
+  - "octoprint-proxy/**"
+  - "!octoprint-proxy/*.md"
+  - "!octoprint-proxy/images/**"
+  - "!octoprint-proxy/icon.png"
+  - "!octoprint-proxy/logo.png"
+  - "!octoprint-proxy/changelog.d/**"
+
+planefence:
+  - "planefence/**"
+  - "!planefence/*.md"
+  - "!planefence/images/**"
+  - "!planefence/icon.png"
+  - "!planefence/logo.png"
+  - "!planefence/changelog.d/**"
+
+toogoodtogo-ha-mqtt-bridge:
+  - "toogoodtogo-ha-mqtt-bridge/**"
+  - "!toogoodtogo-ha-mqtt-bridge/*.md"
+  - "!toogoodtogo-ha-mqtt-bridge/images/**"
+  - "!toogoodtogo-ha-mqtt-bridge/icon.png"
+  - "!toogoodtogo-ha-mqtt-bridge/logo.png"
+  - "!toogoodtogo-ha-mqtt-bridge/changelog.d/**"

--- a/.github/workflows/onpush_build.yaml
+++ b/.github/workflows/onpush_build.yaml
@@ -6,12 +6,15 @@ name: Builder
 env:
   BUILD_ARGS: ""
 
+# No `paths:` filter here on purpose. It used to be "**/config.*", which meant a
+# Dockerfile or rootfs change never reached the builder at all, so Renovate's base
+# image bumps merged green and were never published. Which add-on actually needs
+# rebuilding is decided in one place, .github/paths-filter.yml, by the job below;
+# a second, narrower filter on the trigger could only ever disagree with it.
 on:
   push:
     branches:
       - main
-    paths:
-      - "**/config.*"
 
 jobs:
   check-addon-changes:
@@ -27,6 +30,11 @@ jobs:
         id: filter
         with:
           filters: .github/paths-filter.yml
+          # The filters use "!" to exclude docs and artwork. Under the default
+          # "some" quantifier a negated pattern matches every file it does not
+          # name, so every filter would match everything. "some-with-excludes"
+          # is the one that reads them as exclusions.
+          predicate-quantifier: some-with-excludes
 
   lint_config:
     if: ${{ needs.check-addon-changes.outputs.changedAddons != '[]' }}


### PR DESCRIPTION
**Renovate's base-image bumps have never shipped.** PRs #531 and #532 are sitting on this right now, and every base-image bump before them had the same fate.

### The bug

Two filters both said `config.*`:

```yaml
# .github/workflows/onpush_build.yaml
on:
  push:
    paths:
      - "**/config.*"        # <- Dockerfile change never even starts the workflow

# .github/paths-filter.yml
adsb-multi-portal-feeder: adsb-multi-portal-feeder/config.*   # <- and never selects the add-on
```

So a Dockerfile-only PR merges green, rebuilds nothing, publishes nothing. The `thomx/fr24feed-piaware` bump in #532 would silently never reach anyone.

### The fix

`paths-filter.yml` now lists what actually ends up inside the image, per add-on — `Dockerfile`, `config.*`, `build.*`, `rootfs/**`, `root/**`, `translations/`, loose scripts — while excluding docs and artwork:

```yaml
toogoodtogo-ha-mqtt-bridge:
  - "toogoodtogo-ha-mqtt-bridge/**"
  - "!toogoodtogo-ha-mqtt-bridge/*.md"
  - "!toogoodtogo-ha-mqtt-bridge/images/**"
  - "!toogoodtogo-ha-mqtt-bridge/icon.png"
  - "!toogoodtogo-ha-mqtt-bridge/logo.png"
  - "!toogoodtogo-ha-mqtt-bridge/changelog.d/**"
```

Poeschl's original just uses `<addon>/**`. The exclusions are so a README edit doesn't rebuild five architectures.

**The exclusions need `predicate-quantifier: some-with-excludes`.** This is the part that would silently misbehave otherwise: under the default `some` quantifier, a negated pattern matches every file it *doesn't* name, so `!<addon>/*.md` matches `some-other-addon/Dockerfile` and every filter matches everything. I tested the patterns against real paths with micromatch using both quantifiers — 14 cases, all correct under `some-with-excludes`, 5 wrong under `some`. The option exists in the pinned `v4.0.3`.

The trigger's own `paths:` filter is removed. Which add-on needs rebuilding is decided in `paths-filter.yml`; a second, narrower filter on the trigger can only disagree with it, which is what happened here. The `check-addon-changes` job is a few seconds and everything downstream is gated on `changedAddons != '[]'`.

Also drops the `cups-dev` entry — there is no such directory in this repo.

### What this does and does not fix

It makes a merged Dockerfile change **rebuild and republish**. It does **not** make existing installs update: Supervisor compares `app.version` to `store.version` and raises `AppNoUpdateAvailableError` when they match, so re-pushing the same tag reaches fresh installs only.

Closing that needs a `version:` bump on build-input changes — which `CLAUDE.md` already mandates ("Bump the version on every commit") but Renovate does not do. That is a policy question about how you want bot PRs handled, so it is a separate PR rather than bundled here.

The add-on label check greps this file for `^\s*<addon>:`, which still matches the new format — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)