### PR TITLE
Test what cont-init turns options.json into

### DIFF
--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -163,11 +163,11 @@ jobs:
         id: labels
         shell: bash
         run: |
-          labels="io.hash.version=${{ steps.information.outputs.version }}"
-          labels=$(printf '%s' "$labels\nio.hash.name=${{ steps.information.outputs.name }}")
-          labels=$(printf '%s' "$labels\nio.hash.description=${{ steps.information.outputs.description }}")
-          labels=$(printf '%s' "$labels\nio.hash.type=addon")
-          labels=$(printf '%s' "$labels\nio.hash.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
+          labels="io.hass.version=${{ steps.information.outputs.version }}"
+          labels=$(printf '%s' "$labels\nio.hass.name=${{ steps.information.outputs.name }}")
+          labels=$(printf '%s' "$labels\nio.hass.description=${{ steps.information.outputs.description }}")
+          labels=$(printf '%s' "$labels\nio.hass.type=addon")
+          labels=$(printf '%s' "$labels\nio.hass.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.title=${{ steps.information.outputs.name }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.description=${{ steps.information.outputs.description }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.version=${{ steps.information.outputs.version }}")
@@ -177,11 +177,11 @@ jobs:
           labels=$(printf '%s' "$labels\norg.opencontainers.image.created=$(date -Is)")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.revision=${GITHUB_SHA}")
           echo "Generic labels: $labels"
-          armhf_labels=$(printf '%s' "$labels\nio.hash.arch=armhf")
-          armv7_labels=$(printf '%s' "$labels\nio.hash.arch=armv7")
-          aarch64_labels=$(printf '%s' "$labels\nio.hash.arch=aarch64")
-          amd64_labels=$(printf '%s' "$labels\nio.hash.arch=amd64")
-          i386_labels=$(printf '%s' "$labels\nio.hash.arch=i386")
+          armhf_labels=$(printf '%s' "$labels\nio.hass.arch=armhf")
+          armv7_labels=$(printf '%s' "$labels\nio.hass.arch=armv7")
+          aarch64_labels=$(printf '%s' "$labels\nio.hass.arch=aarch64")
+          amd64_labels=$(printf '%s' "$labels\nio.hass.arch=amd64")
+          i386_labels=$(printf '%s' "$labels\nio.hass.arch=i386")
           armhf_labels="${armhf_labels//$'\n'/'%0A'}"
           armv7_labels="${armv7_labels//$'\n'/'%0A'}"
           aarch64_labels="${aarch64_labels//$'\n'/'%0A'}"

--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -163,11 +163,11 @@ jobs:
         id: labels
         shell: bash
         run: |
-          labels="io.hass.version=${{ steps.information.outputs.version }}"
-          labels=$(printf '%s' "$labels\nio.hass.name=${{ steps.information.outputs.name }}")
-          labels=$(printf '%s' "$labels\nio.hass.description=${{ steps.information.outputs.description }}")
-          labels=$(printf '%s' "$labels\nio.hass.type=addon")
-          labels=$(printf '%s' "$labels\nio.hass.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
+          labels="io.hash.version=${{ steps.information.outputs.version }}"
+          labels=$(printf '%s' "$labels\nio.hash.name=${{ steps.information.outputs.name }}")
+          labels=$(printf '%s' "$labels\nio.hash.description=${{ steps.information.outputs.description }}")
+          labels=$(printf '%s' "$labels\nio.hash.type=addon")
+          labels=$(printf '%s' "$labels\nio.hash.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.title=${{ steps.information.outputs.name }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.description=${{ steps.information.outputs.description }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.version=${{ steps.information.outputs.version }}")
@@ -177,11 +177,11 @@ jobs:
           labels=$(printf '%s' "$labels\norg.opencontainers.image.created=$(date -Is)")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.revision=${GITHUB_SHA}")
           echo "Generic labels: $labels"
-          armhf_labels=$(printf '%s' "$labels\nio.hass.arch=armhf")
-          armv7_labels=$(printf '%s' "$labels\nio.hass.arch=armv7")
-          aarch64_labels=$(printf '%s' "$labels\nio.hass.arch=aarch64")
-          amd64_labels=$(printf '%s' "$labels\nio.hass.arch=amd64")
-          i386_labels=$(printf '%s' "$labels\nio.hass.arch=i386")
+          armhf_labels=$(printf '%s' "$labels\nio.hash.arch=armhf")
+          armv7_labels=$(printf '%s' "$labels\nio.hash.arch=armv7")
+          aarch64_labels=$(printf '%s' "$labels\nio.hash.arch=aarch64")
+          amd64_labels=$(printf '%s' "$labels\nio.hash.arch=amd64")
+          i386_labels=$(printf '%s' "$labels\nio.hash.arch=i386")
           armhf_labels="${armhf_labels//$'\n'/'%0A'}"
           armv7_labels="${armv7_labels//$'\n'/'%0A'}"
           aarch64_labels="${aarch64_labels//$'\n'/'%0A'}"
@@ -287,3 +287,81 @@ jobs:
         run: |
           rm -rf /tmp/buildx-cache
           mv /tmp/buildx-cache-new /tmp/buildx-cache
+
+  # Add-ons opt in by dropping a test/*.test.sh next to their config. Discovered
+  # rather than listed so adding a test to another add-on needs no workflow edit.
+  find-tested-addons:
+    name: Find add-ons with tests
+    runs-on: ubuntu-latest
+    outputs:
+      addons: ${{ steps.find.outputs.addons }}
+    steps:
+      - name: ↩️ Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: 🔎 Find add-ons with tests
+        id: find
+        shell: bash
+        run: |
+          shopt -s nullglob
+          addons=()
+          for t in */test/*.test.sh; do
+            addons+=("${t%%/*}")
+          done
+          # shellcheck disable=SC2207
+          addons=($(printf '%s\n' "${addons[@]}" | sort -u))
+          printf 'Found: %s\n' "${addons[*]:-none}"
+          printf '%s\n' "${addons[@]}" | jq -R -s -c 'split("\n")[:-1]' \
+            | sed 's/^/addons=/' >> "$GITHUB_OUTPUT"
+
+  # Deliberately not folded into check-build: that job only runs for add-ons
+  # whose config.* changed, so a test-only or rootfs-only change would never
+  # exercise its own test.
+  addon-tests:
+    name: Test ${{ matrix.addon }}
+    needs: find-tested-addons
+    if: ${{ needs.find-tested-addons.outputs.addons != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        addon: ${{ fromJSON(needs.find-tested-addons.outputs.addons) }}
+    steps:
+      - name: ↩️ Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: ℹ️ Gather addon info
+        id: information
+        uses: frenck/action-addon-information@v1.4.2
+        with:
+          path: "./${{ matrix.addon }}/"
+
+      - name: 💽 Resolve amd64 base image
+        id: build_args
+        shell: bash
+        run: |
+          build_from=$(jq -r '.build_from.amd64 // empty' "${{ steps.information.outputs.build }}")
+          echo "amd64=BUILD_FROM=${build_from}" >> "$GITHUB_OUTPUT"
+
+      - name: 🏗️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.3.0
+
+      - name: 💿 Build ${{ matrix.addon }} for amd64
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: ${{ matrix.addon }}
+          push: false
+          load: true
+          file: ${{ matrix.addon }}/Dockerfile
+          tags: addon-under-test:amd64
+          build-args: ${{ steps.build_args.outputs.amd64 }}
+
+      - name: 🧪 Run tests
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for t in "${{ matrix.addon }}"/test/*.test.sh; do
+            echo "::group::${t}"
+            bash "${t}" addon-under-test:amd64
+            echo "::endgroup::"
+          done

--- a/toogoodtogo-ha-mqtt-bridge/test/cont-init.test.sh
+++ b/toogoodtogo-ha-mqtt-bridge/test/cont-init.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Runs the add-on's cont-init script inside the built image and checks what it
+# turns /data/options.json into.
+#
+# Home Assistant only supports two levels of nesting in an add-on's options, so
+# the script flattens intense_fetch into two sibling keys in config.yaml and jq
+# folds them back into the nested shape the bridge expects. Nothing tested that
+# until now, and it is exactly the kind of transform that breaks quietly: a jq
+# typo yields nulls rather than an error, and the bridge starts anyway.
+#
+# Usage: cont-init.test.sh <image-tag>
+set -euo pipefail
+
+IMAGE="${1:?usage: cont-init.test.sh <image-tag>}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT=/etc/cont-init.d/toogoodtogo-ha-mqtt-bridge.sh
+SETTINGS=/app/toogoodtogo_ha_mqtt_bridge/settings.local.json
+
+fail() {
+  echo "::error::$*"
+  exit 1
+}
+
+# The script's shebang is `#!/usr/bin/with-contenv bashio`, which needs s6's
+# container_environment directory. Invoking bashio as the interpreter runs the
+# script with the library sourced and skips that dependency: bashio's runner is
+# `BASH_ARGV0=${1:?}; shift; source "$0" "$@"`.
+run_cont_init() {
+  local options_file="$1"
+  docker run --rm \
+    -v "${options_file}:/data/options.json:ro" \
+    --entrypoint /bin/bash \
+    "${IMAGE}" -c \
+    "/usr/bin/bashio ${SCRIPT} >&2 && cat ${SETTINGS}"
+}
+
+echo "--- a complete config is folded into the nested shape the bridge reads"
+settings="$(run_cont_init "${HERE}/options.json")" ||
+  fail "cont-init failed on a valid options.json"
+
+echo "${settings}" | jq . >/dev/null || fail "cont-init produced invalid JSON"
+
+check() {
+  local filter="$1" want="$2" got
+  got="$(echo "${settings}" | jq -r "${filter}")"
+  [[ "${got}" == "${want}" ]] || fail "${filter}: expected '${want}', got '${got}'"
+  echo "    ok  ${filter} = ${got}"
+}
+
+# The flattening is the part under test.
+check '.tgtg.intense_fetch.interval' '30'
+check '.tgtg.intense_fetch_interval' '30'
+check '.tgtg.intense_fetch.period_of_time' '5'
+check '.tgtg.intense_fetch_period_of_time' '5'
+
+# Everything else must survive the copy untouched.
+check '.mqtt.host' 'mqtt-broker'
+check '.mqtt.port' '1883'
+check '.tgtg.email' 'tester@example.com'
+check '.tgtg.polling_schedule' '*/10 * * * *'
+check '.timezone' 'Europe/Berlin'
+check '.cleanup' 'true'
+
+echo "--- an options.json missing the intense_fetch keys yields nulls, not an error"
+# This is why DOCS.md has to keep listing them. jq's += happily writes null for
+# a key that is not there, so the bridge would start with a broken intense_fetch
+# rather than failing loudly. Asserted so that if jq ever starts erroring here
+# instead, we find out on purpose rather than in an issue report.
+partial="$(mktemp)"
+trap 'rm -f "${partial}"' EXIT
+jq 'del(.tgtg.intense_fetch_interval, .tgtg.intense_fetch_period_of_time)' \
+  "${HERE}/options.json" >"${partial}"
+
+partial_settings="$(run_cont_init "${partial}")" ||
+  fail "cont-init should not crash on a config missing intense_fetch keys"
+
+got="$(echo "${partial_settings}" | jq -r '.tgtg.intense_fetch.interval')"
+[[ "${got}" == "null" ]] ||
+  fail ".tgtg.intense_fetch.interval: expected 'null' for a partial config, got '${got}'"
+echo "    ok  missing keys produce null, silently, as documented"
+
+echo "--- all assertions passed"

--- a/toogoodtogo-ha-mqtt-bridge/test/options.json
+++ b/toogoodtogo-ha-mqtt-bridge/test/options.json
@@ -1,0 +1,18 @@
+{
+  "mqtt": {
+    "host": "mqtt-broker",
+    "port": 1883,
+    "username": "mqtt-user",
+    "password": "mqtt-secret"
+  },
+  "tgtg": {
+    "email": "tester@example.com",
+    "language": "en-US",
+    "polling_schedule": "*/10 * * * *",
+    "intense_fetch_interval": 30,
+    "intense_fetch_period_of_time": 5
+  },
+  "timezone": "Europe/Berlin",
+  "locale": "en_us",
+  "cleanup": true
+}


### PR DESCRIPTION
The first test in this repo that actually **runs** an add-on. Everything until now built images and never started one.

### What it covers

Home Assistant only allows two levels of nesting in add-on options, so `config.yaml` flattens `intense_fetch` into two sibling keys and `cont-init` uses `jq` to fold them back into the nested shape the bridge reads:

```bash
jq ".tgtg += { intense_fetch: { interval: .tgtg.intense_fetch_interval, period_of_time: .tgtg.intense_fetch_period_of_time}}"
```

Nothing checked that, and it is exactly the kind of transform that breaks quietly. **`jq`'s `+=` writes `null` for a key that isn't there rather than failing**, so the bridge starts with a broken `intense_fetch` and you find out from an issue report.

The test runs the real `cont-init` inside the freshly built image against a synthetic `/data/options.json` and asserts the output — including the negative case, that a config missing those keys yields nulls. That second assertion is the machine-readable reason `DOCS.md` has to keep listing them (which is what #576 fixed).

### Two implementation notes worth reviewing

**No mock Supervisor is needed here, and I checked rather than assumed.** `bashio::config` reads options from the Supervisor REST API, *not* from `/data/options.json`, so a naive `docker run -v options.json:/data/options.json` proves nothing for most add-ons. This one is the exception: its cont-init only calls `bashio::log.*` and `bashio::fs.file_exists`, neither of which touches the API. Add-ons that do call `bashio::config` will need a small mock sidecar.

**bashio is invoked as the interpreter** rather than running the script directly:

```bash
docker run --entrypoint /bin/bash "$IMAGE" -c "/usr/bin/bashio $SCRIPT && cat $SETTINGS"
```

The script's shebang is `#!/usr/bin/with-contenv bashio`, and `with-contenv` needs s6's `/run/s6/container_environment`, which doesn't exist outside a real Supervisor. Going through `bashio` directly works because its runner is `BASH_ARGV0=${1:?}; shift; source "$0" "$@"`.

### Wiring

`addon-tests` discovers participants by globbing `*/test/*.test.sh`, so adding a test to another add-on needs no workflow edit. planefence already has a `test/options.json` and is correctly not picked up.

It is a **separate job, not a step inside `check-build`**, because `check-build` only runs for add-ons whose `config.*` changed — so a test-only or `rootfs/`-only change would never run its own test. That is the same class of bug as #579.

### Honest caveat

**I can't run Docker in my environment, so this PR's CI run is the first real execution of this test.** If it's red, that's me iterating, not the add-on being broken — I'll fix it from the logs. The shell itself is shellcheck-clean and the discovery logic I did verify locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)