### PR TITLE
Accept a changelog fragment instead of demanding a release

### DIFF
--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -51,8 +51,11 @@ jobs:
       - name: Find changed changelog files
         id: find_changelog
         run: |
+          # Either a released CHANGELOG.md, or a towncrier news fragment under
+          # changelog.d/. A normal PR should only ever add the fragment; the
+          # CHANGELOG.md is written by /release, when towncrier folds them in.
           changed_changelog_files=$(git diff --name-only origin/main "${{ github.sha }}" \
-            | grep -iE '^([^/]+/)?changelog\.(md|txt|ya?ml|json)$' || true)
+            | grep -iE '^([^/]+/)?(changelog\.(md|txt|ya?ml|json)|changelog\.d/.+\.md)$' || true)
           echo "Changed changelog files:"
           echo "$changed_changelog_files"
           echo "changed_changelog_files=$(echo "$changed_changelog_files" | jq -R -s -c 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
@@ -67,12 +70,18 @@ jobs:
       matrix:
         addon: ${{ fromJSON(needs.check-addon-changes.outputs.changedAddons) }}
     steps:
-      - name: 🔎 Check for updated CHANGELOG.md
+      - name: 🔎 Check the change is recorded
         shell: bash
+        env:
+          CHANGELOG_FILES: ${{ needs.check-addon-changes.outputs.changedChangelogFiles }}
+          ADDON: ${{ matrix.addon }}
         run: |
-          # shellcheck disable=SC2076,SC2059
-          if [[ ! "${{ needs.check-addon-changes.outputs.changedChangelogFiles }}" =~ "${{ matrix.addon }}/CHANGELOG.md" ]]; then
-            echo "::error::No new entries in ${{ matrix.addon }} CHANGELOG.md file!"
+          if [[ "${CHANGELOG_FILES}" == *"${ADDON}/changelog.d/"* ]]; then
+            echo "Found a news fragment for ${ADDON}."
+          elif [[ "${CHANGELOG_FILES}" == *"${ADDON}/CHANGELOG.md"* ]]; then
+            echo "Found a CHANGELOG.md entry for ${ADDON} (this looks like a release)."
+          else
+            echo "::error::Nothing records this change for ${ADDON}. Add a news fragment, e.g. ${ADDON}/changelog.d/<PR-number>.fixed.md, with one line describing the change. Types: added, changed, deprecated, fixed, removed, security. Do not bump the version or edit CHANGELOG.md by hand -- /release ${ADDON} does both."
             exit 1
           fi
 
@@ -163,11 +172,11 @@ jobs:
         id: labels
         shell: bash
         run: |
-          labels="io.hass.version=${{ steps.information.outputs.version }}"
-          labels=$(printf '%s' "$labels\nio.hass.name=${{ steps.information.outputs.name }}")
-          labels=$(printf '%s' "$labels\nio.hass.description=${{ steps.information.outputs.description }}")
-          labels=$(printf '%s' "$labels\nio.hass.type=addon")
-          labels=$(printf '%s' "$labels\nio.hass.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
+          labels="io.hash.version=${{ steps.information.outputs.version }}"
+          labels=$(printf '%s' "$labels\nio.hash.name=${{ steps.information.outputs.name }}")
+          labels=$(printf '%s' "$labels\nio.hash.description=${{ steps.information.outputs.description }}")
+          labels=$(printf '%s' "$labels\nio.hash.type=addon")
+          labels=$(printf '%s' "$labels\nio.hash.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.title=${{ steps.information.outputs.name }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.description=${{ steps.information.outputs.description }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.version=${{ steps.information.outputs.version }}")
@@ -177,11 +186,11 @@ jobs:
           labels=$(printf '%s' "$labels\norg.opencontainers.image.created=$(date -Is)")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.revision=${GITHUB_SHA}")
           echo "Generic labels: $labels"
-          armhf_labels=$(printf '%s' "$labels\nio.hass.arch=armhf")
-          armv7_labels=$(printf '%s' "$labels\nio.hass.arch=armv7")
-          aarch64_labels=$(printf '%s' "$labels\nio.hass.arch=aarch64")
-          amd64_labels=$(printf '%s' "$labels\nio.hass.arch=amd64")
-          i386_labels=$(printf '%s' "$labels\nio.hass.arch=i386")
+          armhf_labels=$(printf '%s' "$labels\nio.hash.arch=armhf")
+          armv7_labels=$(printf '%s' "$labels\nio.hash.arch=armv7")
+          aarch64_labels=$(printf '%s' "$labels\nio.hash.arch=aarch64")
+          amd64_labels=$(printf '%s' "$labels\nio.hash.arch=amd64")
+          i386_labels=$(printf '%s' "$labels\nio.hash.arch=i386")
           armhf_labels="${armhf_labels//$'\n'/'%0A'}"
           armv7_labels="${armv7_labels//$'\n'/'%0A'}"
           aarch64_labels="${aarch64_labels//$'\n'/'%0A'}"

--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -172,11 +172,11 @@ jobs:
         id: labels
         shell: bash
         run: |
-          labels="io.hash.version=${{ steps.information.outputs.version }}"
-          labels=$(printf '%s' "$labels\nio.hash.name=${{ steps.information.outputs.name }}")
-          labels=$(printf '%s' "$labels\nio.hash.description=${{ steps.information.outputs.description }}")
-          labels=$(printf '%s' "$labels\nio.hash.type=addon")
-          labels=$(printf '%s' "$labels\nio.hash.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
+          labels="io.hass.version=${{ steps.information.outputs.version }}"
+          labels=$(printf '%s' "$labels\nio.hass.name=${{ steps.information.outputs.name }}")
+          labels=$(printf '%s' "$labels\nio.hass.description=${{ steps.information.outputs.description }}")
+          labels=$(printf '%s' "$labels\nio.hass.type=addon")
+          labels=$(printf '%s' "$labels\nio.hass.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/master/${{ matrix.addon }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.title=${{ steps.information.outputs.name }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.description=${{ steps.information.outputs.description }}")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.version=${{ steps.information.outputs.version }}")
@@ -186,11 +186,11 @@ jobs:
           labels=$(printf '%s' "$labels\norg.opencontainers.image.created=$(date -Is)")
           labels=$(printf '%s' "$labels\norg.opencontainers.image.revision=${GITHUB_SHA}")
           echo "Generic labels: $labels"
-          armhf_labels=$(printf '%s' "$labels\nio.hash.arch=armhf")
-          armv7_labels=$(printf '%s' "$labels\nio.hash.arch=armv7")
-          aarch64_labels=$(printf '%s' "$labels\nio.hash.arch=aarch64")
-          amd64_labels=$(printf '%s' "$labels\nio.hash.arch=amd64")
-          i386_labels=$(printf '%s' "$labels\nio.hash.arch=i386")
+          armhf_labels=$(printf '%s' "$labels\nio.hass.arch=armhf")
+          armv7_labels=$(printf '%s' "$labels\nio.hass.arch=armv7")
+          aarch64_labels=$(printf '%s' "$labels\nio.hass.arch=aarch64")
+          amd64_labels=$(printf '%s' "$labels\nio.hass.arch=amd64")
+          i386_labels=$(printf '%s' "$labels\nio.hass.arch=i386")
           armhf_labels="${armhf_labels//$'\n'/'%0A'}"
           armv7_labels="${armv7_labels//$'\n'/'%0A'}"
           aarch64_labels="${aarch64_labels//$'\n'/'%0A'}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 ## General
 
-- Bump the version on **every commit**, no matter how small the change
-- Update `CHANGELOG.md` alongside every version bump with a brief description of what changed
 - Always `git pull --rebase` before pushing to avoid rejected pushes
+
+## Changelog and releasing
+
+Releases are batched, not per-commit. Do **not** bump `version:` in `config.yaml` and do **not** edit an
+add-on's `CHANGELOG.md` by hand.
+
+- A PR that changes an add-on adds a towncrier news fragment instead:
+  `<addon>/changelog.d/<PR-number>.<type>.md`, one line describing the change.
+  Types: `added`, `changed`, `deprecated`, `fixed`, `removed`, `security`.
+- Renovate PRs get their fragment written automatically by `update-changelog.yml`.
+- Commenting `/release <addon>` (or adding the `release` label to a PR) is what bumps the version, runs
+  `towncrier build` to fold the fragments into `CHANGELOG.md`, and pushes. That config change is what
+  triggers `onpush_build.yaml` to publish the new image tag.
+
+So a fix can sit on `main` unreleased. It reaches users at the next `/release` of that add-on, which is
+deliberate — several small changes ship as one version rather than one each.
+
+Docs, tests, CI and repo-level files never need any of this: they do not end up in the image, and
+`.github/paths-filter.yml` excludes them from triggering a build.


### PR DESCRIPTION
You were right that #580 didn't need a release. This is why it ended up with one.

### The contradiction

The repo already batches releases through towncrier:

- a PR adds `<addon>/changelog.d/<PR>.<type>.md` (Renovate's are written automatically by `update-changelog.yml`)
- `/release <addon>` bumps `config.yaml`, runs `towncrier build` to fold the fragments into `CHANGELOG.md`, and pushes
- that config change is what makes `onpush_build.yaml` publish a new tag

But `check-changed-changelog` required `<addon>/CHANGELOG.md` whenever `config.*` changed — **the one file an ordinary PR should never touch.** The only way to make it green was to do a release. That's backwards, and it's exactly why my #578 and #580 arrived with version bumps they didn't need.

There are 18 unreleased fragments sitting in `toogoodtogo-ha-mqtt-bridge/changelog.d/`, which is the system working. The check just didn't know about them.

### The change

It now accepts **either**:

- `<addon>/changelog.d/*.md` — an ordinary change
- `<addon>/CHANGELOG.md` — the release commit itself

and the failure message now says what to add rather than just "no new entries":

> Nothing records this change for `<addon>`. Add a news fragment, e.g. `<addon>/changelog.d/<PR-number>.fixed.md`, with one line describing the change. Types: added, changed, deprecated, fixed, removed, security. Do not bump the version or edit CHANGELOG.md by hand — `/release <addon>` does both.

The comparison also moved from `=~` on an interpolated expression to `==` with `env:` — same reason as #577, and it drops the `# shellcheck disable=SC2076,SC2059` that was papering over the regex-vs-glob confusion.

### CLAUDE.md

It said *"Bump the version on every commit, no matter how small the change"*, which contradicts the release flow and is presumably what I followed into the hole. Replaced with what the repo actually does, plus the explicit note that **docs, tests and CI changes need none of this** — they don't end up in the image, and `paths-filter.yml` already excludes them from triggering a build.

### Already applied

#578 and #580 are updated: both now carry a fragment instead of a version bump and a hand-written CHANGELOG entry. #578 currently fails this very check, which is the demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)