### PR TITLE
Stop typos rewriting io.hass to io.hash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,11 @@ ci:
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    # Pinned, not `v1`: that is a moving tag, so pre-commit never updates the
+    # cached environment and different machines silently run different versions
+    # with different dictionaries. pre-commit warns about it on every run.
+    # Run `pre-commit autoupdate` to move it.
+    rev: v1.50.0
     hooks:
       - id: typos
   - repo: https://github.com/reteps/dockerfmt

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,13 @@
+# Words this repo uses that `typos` reads as mistakes. Each one here is a real
+# identifier, so an "autocorrection" is a silent breakage rather than a nit.
+#
+# hass       Home Assistant's own abbreviation. It appears in the image labels
+#            Supervisor reads (io.hass.version, io.hass.type, io.hass.arch, ...)
+#            and in hostnames. typos rewrites it to `hash`.
+# mosquitto  The MQTT broker. typos reads it as a misspelling of `mosquito` and
+#            rewrites core-mosquitto, which is a real add-on hostname.
+#
+# Both were caught after the hook had already rewritten them in a pull request.
+[default.extend-words]
+hass = "hass"
+mosquitto = "mosquitto"


### PR DESCRIPTION
> Merge this one first. It stops the hook corrupting identifiers in every other branch.

You spotted this in #584. It is not cosmetic.

### What the hook does

`typos` reports `hass` as a misspelling of `hash`, and the pre-commit hook runs with `--write`:

```
$ typos .github/workflows/onpr_check-pr.yaml
error: `hass` should be `hash`
    ╭▸ .github/workflows/onpr_check-pr.yaml:166:22
    │
166 │           labels="io.hass.version=${{ steps.information.outputs.version }}"
    ╰╴                     ━━━━
... 13 occurrences
```

Those are the **image labels Supervisor reads** — `io.hass.version`, `io.hass.name`, `io.hass.description`, `io.hass.type`, `io.hass.url`, and `io.hass.arch` for all five architectures. It does the same to the ten `io.hass.type` hide-label arguments in `portainer/rootfs/etc/services.d/portainer/run`.

It also rewrites `mosquitto` → `mosquito`, and `core-mosquitto` is a real add-on hostname.

### Why nothing caught it

`ci: skip: [typos]` — pre-commit.ci does not run this hook. So a rewrite lands, CI stays green, and the only way to notice is reading the diff. Which is what you did.

### The fix

`_typos.toml` pins both words. Neither is a typo; both are identifiers, so an "autocorrection" is a silent breakage.

The 20 other findings in the repo are all genuine prose typos in READMEs and comments (`Recived`, `necesarry`, `provivde`, …) — none are identifiers, so nothing else needs pinning. Not fixing those here.

### Also pinning the rev

```diff
-    rev: v1
+    rev: v1.50.0
```

`v1` is a moving tag. pre-commit never updates a cached environment for a mutable ref — it warns about exactly this on every run — so different machines run different `typos` versions with different dictionaries and get different rewrites. That is also why this was hard to reproduce: it depends on when your hook environment was first installed.

`dockerfmt` and `prettier` are already pinned to real versions.

### Cleanup in flight

#583 and #584 both carry the `io.hash` corruption; I am reverting it in both. #583 is currently green, so it would have merged the broken labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)