### PR TITLE
Keep the lubeda credit, drop the dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Forwards Eufy Security push notifications to Home Assistant via MQTT.
 
 (AWsome maTRIX) is a full color dot matrix that displays applications from simple time display to Fortnite account statistics.
 
-Most of the work was done from/within https://github.com/lubeda/repository - I just made it work and adjusted some little things.
+Most of the work was done from/within [lubeda](https://github.com/lubeda)'s add-on repository, since removed from GitHub - I just made it work and adjusted some little things.
 
 Made for the awesome AWTRIX project by blueforcer. Even it is discontinued, I like it.
 

--- a/awtrix/README.md
+++ b/awtrix/README.md
@@ -2,7 +2,7 @@
 
 <a href='https://ko-fi.com/MaxWinterstein' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
-## Based on (aka. stolen from) https://github.com/lubeda/repository
+## Based on (aka. stolen from) [lubeda](https://github.com/lubeda)'s add-on repository, since removed from GitHub
 
 Thanks for the work! I just made it work again for Raspberry Pi, and did some tweaking here and there.
 
@@ -22,9 +22,9 @@ There is no arrangement with blueforcer, so i build this by try and error. It wo
 
 ## Usage
 
-Access the server via ingress, so no port config is necesarry
+Access the server via ingress, so no port config is necessary
 
-The config and the apps folder are accesible as /config/awtrix/apps and /config/awtrix/config. So no ftp is needed
+The config and the apps folder are accessible as /config/awtrix/apps and /config/awtrix/config. So no ftp is needed
 
 | option  | default | usage                                                                                                                                          |
 | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Two-line doc fix.

`https://github.com/lubeda/repository` has been deleted (it was still live in a Sept 2025 Wayback capture), so both places crediting it link to a 404:

- `README.md:77`
- `awtrix/README.md:5` — where it's an H2 heading

The attribution is worth keeping, so it now points at [lubeda](https://github.com/lubeda) (profile still exists) and says the repository is gone rather than implying it's still there. lubeda has no successor repo of that name.

Also included: the `typos` hook fixed **necesarry** → necessary and **accesible** → accessible in `awtrix/README.md`, since that file is in scope. Unrelated but free.

First PR since `_typos.toml` landed, and it behaved — no `io.hass` corruption this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)